### PR TITLE
Feature/popular people api

### DIFF
--- a/src/common/FeatureLink/index.js
+++ b/src/common/FeatureLink/index.js
@@ -1,0 +1,10 @@
+import React from "react";
+import { StyledLink } from "./styled";
+
+const FeatureLink = ({children, to}) => (
+    <StyledLink to={to}>
+        {children}
+    </StyledLink>
+);
+
+export default FeatureLink;

--- a/src/common/FeatureLink/styled.js
+++ b/src/common/FeatureLink/styled.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { Link } from "react-router-dom";
 
-export const PersonLink = styled(Link)`
+export const StyledLink = styled(Link)`
     text-decoration: none;
     display:flex;
     justify-content: center;

--- a/src/features/movies/MoviesPage/index.js
+++ b/src/features/movies/MoviesPage/index.js
@@ -7,7 +7,7 @@ import Section from "../../../common/Section";
 import Tile from "../../../common/Tile";
 import LoadingSpinner from "../../../common/LoadingSpinner";
 import Pagination from "../../../common/Pagination";
-import { MovieLink } from "./styled";
+import FeatureLink from "../../../common/FeatureLink";
 import ErrorPage from "../../../common/ErrorPage";
 import { useQueryParameter } from "../../../useQueryParameters";
 import { toMovie } from "../../../routes";
@@ -37,7 +37,7 @@ const MoviesPage = () => {
               title="Popular Movies"
               body={
                 movies.results?.map(movie =>
-                  <MovieLink key={movie.id} to={toMovie(movie)}>
+                  <FeatureLink key={movie.id} to={toMovie(movie)}>
                     <Tile
                       key={movie.id}
                       title={movie.title}
@@ -48,7 +48,7 @@ const MoviesPage = () => {
                       rate={movie.vote_average}
                       votes={movie.vote_count}
                     />
-                  </MovieLink>
+                  </FeatureLink>
                 )
               } />
           </Main>

--- a/src/features/movies/MoviesPage/styled.js
+++ b/src/features/movies/MoviesPage/styled.js
@@ -1,9 +1,0 @@
-import styled from "styled-components";
-import { Link } from "react-router-dom";
-
-export const MovieLink = styled(Link)`
-    text-decoration: none;
-    display:flex;
-    justify-content: center;
-    align-items: flex-start;
-`;

--- a/src/features/movies/MoviesPage/styled.js
+++ b/src/features/movies/MoviesPage/styled.js
@@ -3,4 +3,7 @@ import { Link } from "react-router-dom";
 
 export const MovieLink = styled(Link)`
     text-decoration: none;
+    display:flex;
+    justify-content: center;
+    align-items: flex-start;
 `;

--- a/src/features/people/PeoplePage/index.js
+++ b/src/features/people/PeoplePage/index.js
@@ -4,37 +4,45 @@ import PeopleTile from "../../../common/PeopleTile";
 import Main from "../../../common/Main";
 import Section from "../../../common/Section";
 import Pagination from "../../../common/Pagination";
-import { fetchPopularPeople, selectPopularPeople } from "../popularPeopleSlice";
+import LoadingSpinner from "../../../common/LoadingSpinner";
+import ErrorPage from "../../../common/ErrorPage";
+import { fetchPopularPeople, selectPopularPeople, selectPopularPeopleLoadingState, selectPopularPeopleErrorState } from "../popularPeopleSlice";
 
 const PeoplePage = () => {
 
   const dispatch = useDispatch();
   const popularPeople = useSelector(selectPopularPeople).results;
+  const popularPeopleLoading = useSelector(selectPopularPeopleLoadingState);
+  const popularPeopleError = useSelector(selectPopularPeopleErrorState);
 
   useEffect(() => {
     dispatch(fetchPopularPeople(1));
-  },[dispatch])
+  }, [dispatch])
 
   return (
-    <>
-      <Main>
-        <Section
-          type="people"
-          grid
-          title="Popular People"
-          body={popularPeople && popularPeople.map(popularPerson => (
-            <PeopleTile
-              name={popularPerson.name}
-              birthCity={popularPerson.place_of_birth}
-              birthDate={popularPerson.birthday}
-              poster={popularPerson.profile_path}
-              description={popularPerson.biography}
-            />
-          ))}
-        />
-      </Main>
-      <Pagination type="people" />
-    </>
+    <Main>
+      {(!popularPeople && popularPeopleLoading) && <LoadingSpinner />}
+      {(!popularPeople && popularPeopleError) && <ErrorPage />}
+      {popularPeople &&
+        <>
+          <Section
+            type="people"
+            grid
+            title="Popular People"
+            body={popularPeople && popularPeople.map(popularPerson => (
+              <PeopleTile
+                name={popularPerson.name}
+                birthCity={popularPerson.place_of_birth}
+                birthDate={popularPerson.birthday}
+                poster={popularPerson.profile_path}
+                description={popularPerson.biography}
+              />
+            ))}
+          />
+          <Pagination type="people" />
+        </>
+      }
+    </Main>
   )
 };
 

--- a/src/features/people/PeoplePage/index.js
+++ b/src/features/people/PeoplePage/index.js
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from "react-redux";
-import { useLocation } from "react-router-dom";
 import { page as pageParameterName } from "../../../queryParamNames";
 import PeopleTile from "../../../common/PeopleTile";
 import Main from "../../../common/Main";
@@ -8,7 +7,7 @@ import Section from "../../../common/Section";
 import Pagination from "../../../common/Pagination";
 import LoadingSpinner from "../../../common/LoadingSpinner";
 import ErrorPage from "../../../common/ErrorPage";
-import { fetchPopularPeople, selectPopularPeople, selectPopularPeopleLoadingState, selectPopularPeopleErrorState } from "../popularPeopleSlice";
+import { fetchPopularPeople, selectPopularPeople, selectPopularPeopleLoadingState, selectPopularPeopleErrorState, resetPopularPeople } from "../popularPeopleSlice";
 import { useQueryParameter } from "../../../useQueryParameters";
 
 const PeoplePage = () => {
@@ -22,6 +21,9 @@ const PeoplePage = () => {
 
   useEffect(() => {
     dispatch(fetchPopularPeople(query || 1));
+    return (() => {
+      dispatch(resetPopularPeople())
+    })
   }, [dispatch, query])
 
   return (

--- a/src/features/people/PeoplePage/index.js
+++ b/src/features/people/PeoplePage/index.js
@@ -1,59 +1,39 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from "react-redux";
 import PeopleTile from "../../../common/PeopleTile";
 import Main from "../../../common/Main";
 import Section from "../../../common/Section";
 import Pagination from "../../../common/Pagination";
-
-const examplePerson = {
-  name: "Mark Hamill",
-  birthday: "1951-09-25",
-  place_of_birth: "Concord, California, USA",
-  biography: "Mark Richard Hamill (born September 25, 1951) is an American actor, voice artist, producer, director, and writer. Hamill is best known for his role as Luke Skywalker in the original Star Wars trilogy and also well known for voice-acting characters such as the Joker in various animated series, animated films and video games, beginning with Batman: The Animated Series, the Skeleton king in Super Robot Monkey Team Hyperforce Go!, Fire Lord Ozai in Avatar: The Last Airbender, Master Eraqus in Kingdom Hearts: Birth by Sleep, Skips in Regular Show, and Senator Stampington on Metalocalypse.",
-  image: "\/9Wws35pCsT0KoZpiV4Gk5nbn9ZD.jpg",
-}
+import { fetchPopularPeople, selectPopularPeople } from "../popularPeopleSlice";
 
 const PeoplePage = () => {
+
+  const dispatch = useDispatch();
+  const popularPeople = useSelector(selectPopularPeople).results;
+
+  useEffect(() => {
+    dispatch(fetchPopularPeople(1));
+  },[dispatch])
+
   return (
     <>
       <Main>
         <Section
           type="people"
-          // grid
+          grid
           title="Popular People"
-          body={
-            <>
-              {/* Body has been prepared for component's testing - please replace after tests */}
-              <PeopleTile
-                horizontal
-                name={examplePerson.name}
-                birthCity={examplePerson.place_of_birth}
-                birthDate={examplePerson.birthday}
-                poster={examplePerson.image}
-                description={examplePerson.biography}
-              />
-              {/* <PeopleTile />
-              <PeopleTile />
-              <PeopleTile />
-              <PeopleTile />
-              <PeopleTile />
-              <PeopleTile />
-              <PeopleTile />
-              <PeopleTile />
-              <PeopleTile />
-              <PeopleTile />
-              <PeopleTile />
-              <PeopleTile />
-              <PeopleTile />
-              <PeopleTile />
-              <PeopleTile />
-              <PeopleTile />
-              <PeopleTile />
-              <PeopleTile />
-              <PeopleTile /> */}
-            </>
-          } />
+          body={popularPeople && popularPeople.map(popularPerson => (
+            <PeopleTile
+              name={popularPerson.name}
+              birthCity={popularPerson.place_of_birth}
+              birthDate={popularPerson.birthday}
+              poster={popularPerson.profile_path}
+              description={popularPerson.biography}
+            />
+          ))}
+        />
       </Main>
-      <Pagination type="movies" />
+      <Pagination type="people" />
     </>
   )
 };

--- a/src/features/people/PeoplePage/index.js
+++ b/src/features/people/PeoplePage/index.js
@@ -7,8 +7,10 @@ import Section from "../../../common/Section";
 import Pagination from "../../../common/Pagination";
 import LoadingSpinner from "../../../common/LoadingSpinner";
 import ErrorPage from "../../../common/ErrorPage";
+import { PersonLink } from "./styled";
 import { fetchPopularPeople, selectPopularPeople, selectPopularPeopleLoadingState, selectPopularPeopleErrorState, resetPopularPeople } from "../popularPeopleSlice";
 import { useQueryParameter } from "../../../useQueryParameters";
+import { toPerson } from "../../../routes";
 
 const PeoplePage = () => {
 
@@ -17,7 +19,6 @@ const PeoplePage = () => {
   const popularPeopleLoading = useSelector(selectPopularPeopleLoadingState);
   const popularPeopleError = useSelector(selectPopularPeopleErrorState);
   const query = useQueryParameter(pageParameterName);
-  console.log(query);
 
   useEffect(() => {
     dispatch(fetchPopularPeople(query || 1));
@@ -37,14 +38,15 @@ const PeoplePage = () => {
             grid
             title="Popular People"
             body={popularPeople && popularPeople.map(popularPerson => (
-              <PeopleTile
-                key={popularPerson.id}
-                name={popularPerson.name}
-                birthCity={popularPerson.place_of_birth}
-                birthDate={popularPerson.birthday}
-                poster={popularPerson.profile_path}
-                description={popularPerson.biography}
-              />
+              <PersonLink key={popularPerson.id} to={toPerson(popularPerson)}>
+                <PeopleTile
+                  name={popularPerson.name}
+                  birthCity={popularPerson.place_of_birth}
+                  birthDate={popularPerson.birthday}
+                  poster={popularPerson.profile_path}
+                  description={popularPerson.biography}
+                />
+              </PersonLink>
             ))}
           />
           <Pagination type="people" />

--- a/src/features/people/PeoplePage/index.js
+++ b/src/features/people/PeoplePage/index.js
@@ -7,7 +7,7 @@ import Section from "../../../common/Section";
 import Pagination from "../../../common/Pagination";
 import LoadingSpinner from "../../../common/LoadingSpinner";
 import ErrorPage from "../../../common/ErrorPage";
-import { PersonLink } from "./styled";
+import FeatureLink from "../../../common/FeatureLink";
 import { fetchPopularPeople, selectPopularPeople, selectPopularPeopleLoadingState, selectPopularPeopleErrorState, resetPopularPeople } from "../popularPeopleSlice";
 import { useQueryParameter } from "../../../useQueryParameters";
 import { toPerson } from "../../../routes";
@@ -38,7 +38,7 @@ const PeoplePage = () => {
             grid
             title="Popular People"
             body={popularPeople && popularPeople.map(popularPerson => (
-              <PersonLink key={popularPerson.id} to={toPerson(popularPerson)}>
+              <FeatureLink key={popularPerson.id} to={toPerson(popularPerson)}>
                 <PeopleTile
                   name={popularPerson.name}
                   birthCity={popularPerson.place_of_birth}
@@ -46,7 +46,7 @@ const PeoplePage = () => {
                   poster={popularPerson.profile_path}
                   description={popularPerson.biography}
                 />
-              </PersonLink>
+              </FeatureLink>
             ))}
           />
           <Pagination type="people" />

--- a/src/features/people/PeoplePage/index.js
+++ b/src/features/people/PeoplePage/index.js
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from "react-redux";
+import { useLocation } from "react-router-dom";
 import PeopleTile from "../../../common/PeopleTile";
 import Main from "../../../common/Main";
 import Section from "../../../common/Section";
@@ -14,10 +15,13 @@ const PeoplePage = () => {
   const popularPeople = useSelector(selectPopularPeople).results;
   const popularPeopleLoading = useSelector(selectPopularPeopleLoadingState);
   const popularPeopleError = useSelector(selectPopularPeopleErrorState);
+  const location = useLocation();
+  const query = new URLSearchParams(location.search).get("page");
+  console.log(query);
 
   useEffect(() => {
-    dispatch(fetchPopularPeople(1));
-  }, [dispatch])
+    dispatch(fetchPopularPeople(query || 1));
+  }, [dispatch, query])
 
   return (
     <Main>
@@ -31,6 +35,7 @@ const PeoplePage = () => {
             title="Popular People"
             body={popularPeople && popularPeople.map(popularPerson => (
               <PeopleTile
+                key={popularPerson.id}
                 name={popularPerson.name}
                 birthCity={popularPerson.place_of_birth}
                 birthDate={popularPerson.birthday}

--- a/src/features/people/PeoplePage/index.js
+++ b/src/features/people/PeoplePage/index.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
+import { page as pageParameterName } from "../../../queryParamNames";
 import PeopleTile from "../../../common/PeopleTile";
 import Main from "../../../common/Main";
 import Section from "../../../common/Section";
@@ -8,6 +9,7 @@ import Pagination from "../../../common/Pagination";
 import LoadingSpinner from "../../../common/LoadingSpinner";
 import ErrorPage from "../../../common/ErrorPage";
 import { fetchPopularPeople, selectPopularPeople, selectPopularPeopleLoadingState, selectPopularPeopleErrorState } from "../popularPeopleSlice";
+import { useQueryParameter } from "../../../useQueryParameters";
 
 const PeoplePage = () => {
 
@@ -15,8 +17,7 @@ const PeoplePage = () => {
   const popularPeople = useSelector(selectPopularPeople).results;
   const popularPeopleLoading = useSelector(selectPopularPeopleLoadingState);
   const popularPeopleError = useSelector(selectPopularPeopleErrorState);
-  const location = useLocation();
-  const query = new URLSearchParams(location.search).get("page");
+  const query = useQueryParameter(pageParameterName);
   console.log(query);
 
   useEffect(() => {

--- a/src/features/people/PeoplePage/styled.js
+++ b/src/features/people/PeoplePage/styled.js
@@ -1,0 +1,6 @@
+import styled from "styled-components";
+import { Link } from "react-router-dom";
+
+export const PersonLink = styled(Link)`
+    text-decoration: none;
+`;

--- a/src/features/people/PeoplePage/styled.js
+++ b/src/features/people/PeoplePage/styled.js
@@ -3,4 +3,7 @@ import { Link } from "react-router-dom";
 
 export const PersonLink = styled(Link)`
     text-decoration: none;
+    display:flex;
+    justify-content: center;
+    align-items: flex-start;
 `;

--- a/src/features/people/popularPeopleSaga.js
+++ b/src/features/people/popularPeopleSaga.js
@@ -1,4 +1,4 @@
-import { takeLatest, call, put } from "redux-saga/effects";
+import { takeLatest, call, put, delay } from "redux-saga/effects";
 import { fetchPopularPeople, fetchPopularPeopleSucces, fetchPopularPeopleError } from "./popularPeopleSlice";
 import { getPopularPeople } from "../../../src/apiClient";
 
@@ -6,6 +6,7 @@ function* fetchPopularPeopleHandler({ payload }) {
   try {
     const page = payload;
     const popularPeople = yield call(getPopularPeople, page);
+    yield delay(500);
     yield put(fetchPopularPeopleSucces(popularPeople));
   } catch (error) {
     yield put(fetchPopularPeopleError());

--- a/src/features/people/popularPeopleSlice.js
+++ b/src/features/people/popularPeopleSlice.js
@@ -27,5 +27,7 @@ const popularPeopleSlice = createSlice({
 
 export const selectPopularPeopleState = state => state.popularPeople;
 export const selectPopularPeople = state => selectPopularPeopleState(state).popularPeople;
+export const selectPopularPeopleLoadingState = state  => selectPopularPeopleState(state).loading;
+export const selectPopularPeopleErrorState = state  => selectPopularPeopleState(state).error;
 export const { fetchPopularPeople, fetchPopularPeopleSucces, fetchPopularPeopleError } = popularPeopleSlice.actions;
 export default popularPeopleSlice.reducer;

--- a/src/features/people/popularPeopleSlice.js
+++ b/src/features/people/popularPeopleSlice.js
@@ -12,7 +12,7 @@ const popularPeopleSlice = createSlice({
       state.loading = true;
     },
 
-    fetchPopularPeopleSucces: (state, { payload: people}) => {
+    fetchPopularPeopleSucces: (state, { payload: people }) => {
       state.popularPeople = people;
       state.loading = false;
       state.error = false;
@@ -22,12 +22,18 @@ const popularPeopleSlice = createSlice({
       state.loading = false;
       state.error = true;
     },
+
+    resetPopularPeople: state => {
+      state.popularPeople = [];
+      state.loading = false;
+      state.error = false;
+    },
   },
 });
 
 export const selectPopularPeopleState = state => state.popularPeople;
 export const selectPopularPeople = state => selectPopularPeopleState(state).popularPeople;
-export const selectPopularPeopleLoadingState = state  => selectPopularPeopleState(state).loading;
-export const selectPopularPeopleErrorState = state  => selectPopularPeopleState(state).error;
-export const { fetchPopularPeople, fetchPopularPeopleSucces, fetchPopularPeopleError } = popularPeopleSlice.actions;
+export const selectPopularPeopleLoadingState = state => selectPopularPeopleState(state).loading;
+export const selectPopularPeopleErrorState = state => selectPopularPeopleState(state).error;
+export const { fetchPopularPeople, fetchPopularPeopleSucces, fetchPopularPeopleError, resetPopularPeople } = popularPeopleSlice.actions;
 export default popularPeopleSlice.reducer;

--- a/src/routes.js
+++ b/src/routes.js
@@ -2,3 +2,4 @@ export const toMovies = () => "/movies";
 export const toPeople = () => "/people";
 
 export const toMovie = ({ id } = { id: ":id" }) => `/movies/${id}`;
+export const toPerson = ({ id } = { id: ":id" }) => `/people/${id}`;


### PR DESCRIPTION
Wrzucam dokończoną stronę PeoplePage z popularPeople, z odpowiednim, wyświetlaniem, interakcjami API i paginacją.
Od razu zwrócę uwagę co tutaj zmieniłem względem popularMovies. Mianowicie zrobiłem coś takiego, że dodałem to useEffect returna z dispatchem funkcji, która resetuje nam stan popularPeople do wartości początkowej i pustej tablicy. Zrobiłem to, bo nie podoba mi się jak to wygląda w przypadku movies, czyli jeśli jesteśmy w sekcji movies np. na 3 stronie i przechodzimy do sekcji people, a następnie chcielibyśmy wrócić do sekcji movies, to mamy tak, że widzimy filmy z 3 strony, bo takie są w state i dopiero potem ładują się filmy z pierwszej strony. Mnie osobiście bardziej podoba się akcja, kiedy przy takim przejściu widzimy ładowanie, niż przejście z pierwszej na trzecią stronę ;)
Druga rzecz to drobne poprawki stylu to komponentu MovieLink i w przypadku people PersonLink, które wcześniej przygotowała @katkowa , dodałem po prostu display flex i wycentrowanie w poziomie oraz w pionie flex-start, ponieważ widziałem, że wprowadzenie tego komponentu popsuło trochę style wyświetlanej listy ;)
W związku z tym dodałem także tą funkcjonalność routera, że po kliknięciu w odpowiednią osobę pokazuje się odpowiedni URL, ale na razie tylko tyle, nie ładuje się jeszcze strona PersonDetails. Jeśli pozwolicie to w następnej kolejności i to pewnie jutro, chciałbym się tym zająć ;)