### PR TITLE
Move genres to separate feature

### DIFF
--- a/src/common/ErrorPage/styled.js
+++ b/src/common/ErrorPage/styled.js
@@ -14,12 +14,21 @@ export const ErrorTitle = styled.h1`
     font-weight: 600;
     line-height: 120%;
     margin: 24px auto;
+
+    @media(max-width: ${({ theme }) => theme.breakpoints.mobileMax}){
+        margin: 12px auto 18px auto;
+        font-size: 20px;
+    }   
 `;
 
 export const ErrorBody = styled.div`
     font-size: 22px;
     font-weight: 500;
     line-height: 130%;
+
+    @media(max-width: ${({ theme }) => theme.breakpoints.mobileMax}){
+        font-size: 14px;
+    }   
 `;
 
 export const ErrorButton = styled.button`
@@ -41,4 +50,11 @@ export const ErrorButton = styled.button`
     &:active {
         filter: brightness(120%);
     }
+
+    @media(max-width: ${({ theme }) => theme.breakpoints.mobileMax}){
+        font-size: 12px;
+        padding: 8px 12px;
+        margin: 18px auto;
+        font-weight: 500;
+    }  
 `;

--- a/src/common/Tile/GenreSection/index.js
+++ b/src/common/Tile/GenreSection/index.js
@@ -2,17 +2,10 @@ import React from "react";
 import { useSelector } from "react-redux";
 import GenreTile from "../GenreTile";
 import { StyledSection } from "./styled";
-import { selectGenresFromMovies } from "../../../features/movies/moviesSlice"
-import { selectGenresFromPeople } from "../../../features/people/peopleSlice";
-import {useLocation} from "react-router-dom";
-import { toMovies } from "../../../routes";
+import { selectGenres } from "../../../features/genres/genresSlice";
 
 const GenreSection = ({ horizontal, genres }) => {
-  const location = useLocation();
-  const genresListFromMovies = useSelector(selectGenresFromMovies);
-  const genresListFromPeople = useSelector(selectGenresFromPeople);
-  let genresList;
-  genresList = location.pathname.includes(toMovies()) ? genresListFromMovies : genresListFromPeople;
+  const genresList = useSelector(selectGenres);
 
   return (
     <StyledSection horizontal={horizontal}>

--- a/src/common/Tile/styled.js
+++ b/src/common/Tile/styled.js
@@ -34,6 +34,7 @@ export const StyledTile = styled.div`
         grid-template-columns: 122px 1fr;
         width: 288px;
         padding: 16px;
+        margin: 0 auto;
         box-shadow: 0px 4px 12px rgba(186, 199, 213, 0.5);
       }
     `};

--- a/src/features/genres/genresSaga.js
+++ b/src/features/genres/genresSaga.js
@@ -1,10 +1,20 @@
-import { takeLatest } from "redux-saga/effects";
-import { fetchGenres } from "./genresSlice";
+import { call, takeLatest, select, put } from "redux-saga/effects";
+import { fetchGenres, fetchGenresError, fetchGenresSucces, selectGenres } from "./genresSlice";
+import { getGenres } from "../../apiClient";
 
-function* fetchGenresHandler(){
-    yield console.log("You' are in saga");
+function* fetchGenresHandler() {
+    try {
+        const stateGenres = yield select(selectGenres);
+        if (stateGenres.length === 0) {
+            const genres = yield call(getGenres);
+            yield put(fetchGenresSucces(genres));
+        }
+    } catch (error) {
+        yield put(fetchGenresError());
+        yield console.log(error);
+    };
 };
 
 export function* genresSaga() {
-    yield takeLatest(fetchGenres.type, fetchGenresHandler)
+    yield takeLatest(fetchGenres.type, fetchGenresHandler);
 };

--- a/src/features/genres/genresSaga.js
+++ b/src/features/genres/genresSaga.js
@@ -1,0 +1,10 @@
+import { takeLatest } from "redux-saga/effects";
+import { fetchGenres } from "./genresSlice";
+
+function* fetchGenresHandler(){
+    yield console.log("You' are in saga");
+};
+
+export function* genresSaga() {
+    yield takeLatest(fetchGenres.type, fetchGenresHandler)
+};

--- a/src/features/genres/genresSlice.js
+++ b/src/features/genres/genresSlice.js
@@ -12,12 +12,10 @@ const genresSlice = createSlice(
             fetchGenres: state => {
                 state.loading = true;
             },
-
-            fetchGenresSucces: (state, {payload: genres} ) => {
+            fetchGenresSucces: (state, { payload: genres }) => {
                 state.genres = genres;
                 state.loading = false;
             },
-
             fetchGenresError: state => {
                 state.loading = false;
                 state.error = true;

--- a/src/features/genres/genresSlice.js
+++ b/src/features/genres/genresSlice.js
@@ -13,8 +13,8 @@ const genresSlice = createSlice(
                 state.loading = true;
             },
 
-            fetchGenresSucces: (state, payload) => {
-                state.genres = payload;
+            fetchGenresSucces: (state, {payload: genres} ) => {
+                state.genres = genres;
                 state.loading = false;
             },
 
@@ -26,6 +26,7 @@ const genresSlice = createSlice(
     }
 );
 
-export const selectGenres = state => state.genres;
+export const selectGenresState = state => state.genres;
+export const selectGenres = state => selectGenresState(state).genres;
 export const { fetchGenres, fetchGenresSucces, fetchGenresError } = genresSlice.actions;
 export default genresSlice.reducer; 

--- a/src/features/genres/genresSlice.js
+++ b/src/features/genres/genresSlice.js
@@ -3,15 +3,29 @@ import { createSlice } from "@reduxjs/toolkit";
 const genresSlice = createSlice(
     {
         name: "genres",
-        initialState: [],
+        initialState: {
+            genres: [],
+            loading: false,
+            error: false,
+        },
         reducers: {
-            setGenres: (state, payload) => {
-                state = payload;
+            fetchGenres: state => {
+                state.loading = true;
             },
+
+            fetchGenresSucces: (state, payload) => {
+                state.genres = payload;
+                state.loading = false;
+            },
+
+            fetchGenresError: state => {
+                state.loading = false;
+                state.error = true;
+            }
         },
     }
 );
 
 export const selectGenres = state => state.genres;
-export const { setGenres } = genresSlice.actions;
+export const { fetchGenres, fetchGenresSucces, fetchGenresError } = genresSlice.actions;
 export default genresSlice.reducer; 

--- a/src/features/genres/genresSlice.js
+++ b/src/features/genres/genresSlice.js
@@ -1,0 +1,17 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const genresSlice = createSlice(
+    {
+        name: "genres",
+        initialState: [],
+        reducers: {
+            setGenres: (state, payload) => {
+                state = payload;
+            },
+        },
+    }
+);
+
+export const selectGenres = state => state.genres;
+export const { setGenres } = genresSlice.actions;
+export default genresSlice.reducer; 

--- a/src/features/movies/MoviesPage/index.js
+++ b/src/features/movies/MoviesPage/index.js
@@ -13,6 +13,7 @@ import { useQueryParameter } from "../../../useQueryParameters";
 import { search as searchParameterName } from "../../../queryParamNames";
 import { toMovie } from "../../../routes";
 import NoResultsPage from "../../../common/NoResultsPage";
+import { fetchGenres } from "../../genres/genresSlice";
 
 const MoviesPage = () => {
 
@@ -25,6 +26,7 @@ const MoviesPage = () => {
 
   useEffect(() => {
     dispatch(fetchPopularMovies({ page: page || 1, query }));
+    dispatch(fetchGenres());
   }, [dispatch, page, query]);
 
   return (

--- a/src/features/movies/moviesSaga.js
+++ b/src/features/movies/moviesSaga.js
@@ -8,7 +8,6 @@ import {
     fetchMovieError,
     fetchMovie,
     resetMovies,
-    resetMovie
 } from "./moviesSlice";
 
 function* fetchPopularMoviesHandler({ payload }) {

--- a/src/features/movies/moviesSaga.js
+++ b/src/features/movies/moviesSaga.js
@@ -26,7 +26,6 @@ function* fetchPopularMoviesHandler({ payload }) {
 
 function* fetchMovieHandler(action) {
     try {
-        yield put(resetMovie());
         const movie = yield call(getMovie, action.payload);
         const credits = yield call(getMovieCredits, action.payload);
         yield put(fetchMovieSucces({ movie, credits }));

--- a/src/features/movies/moviesSaga.js
+++ b/src/features/movies/moviesSaga.js
@@ -1,10 +1,9 @@
-import { takeLatest, call, put, select } from "redux-saga/effects";
-import { getPopularMovies, getGenres, getMovie, getMovieCredits, searchForMovies } from "../../../src/apiClient";
+import { takeLatest, call, put } from "redux-saga/effects";
+import { getPopularMovies, getMovie, getMovieCredits, searchForMovies } from "../../../src/apiClient";
 import {
     fetchPopularMovies,
     fetchPopularMoviesSucces,
     fetchPopularMoviesError,
-    setGenres,
     fetchMovieSucces,
     fetchMovieError,
     fetchMovie,
@@ -19,12 +18,6 @@ function* fetchPopularMoviesHandler({ payload }) {
             ? yield call(searchForMovies, payload.page, payload.query)
             : yield call(getPopularMovies, payload.page);
         yield put(fetchPopularMoviesSucces(popularMovies));
-        
-        const state = yield select();
-        if (state.movies.genres.length === 0) {
-            const genres = yield call(getGenres);
-            yield put(setGenres(genres));
-        }
     } catch (error) {
         yield put(fetchPopularMoviesError());
         console.error(error);

--- a/src/features/movies/moviesSlice.js
+++ b/src/features/movies/moviesSlice.js
@@ -21,23 +21,19 @@ const moviesSlice = createSlice({
             state.loading = false;
             state.error = true;
         },
-
         fetchMovie: (state) => {
             state.loading = true;
         },
-
         fetchMovieSucces: (state, { payload: movieData }) => {
             state.movieData = movieData;
             state.loading = false;
             state.error = false;
         },
-
         resetMovie: (state) => {
             state.movieData = { movie: undefined, credits: undefined };
             state.loading = false;
             state.error = false;
         },
-
         fetchMovieError: (state) => {
             state.loading = false;
             state.error = true;

--- a/src/features/movies/moviesSlice.js
+++ b/src/features/movies/moviesSlice.js
@@ -6,7 +6,6 @@ const moviesSlice = createSlice({
         movies: [],
         loading: false,
         error: false,
-        genres: [],
         movieData: { movie: undefined, credits: undefined },
     },
     reducers: {
@@ -22,14 +21,11 @@ const moviesSlice = createSlice({
             state.loading = false;
             state.error = true;
         },
-        setGenres: (state, { payload: genres }) => {
-            state.genres = genres;
-            state.loading = false;
-            state.error = false;
-        },
+
         fetchMovie: (state) => {
             state.loading = true;
         },
+
         fetchMovieSucces: (state, { payload: movieData }) => {
             state.movieData = movieData;
             state.loading = false;
@@ -56,7 +52,6 @@ export const {
     fetchPopularMovies,
     fetchPopularMoviesSucces,
     fetchPopularMoviesError,
-    setGenres,
     fetchMovie,
     fetchMovieSucces,
     fetchMovieError,
@@ -68,7 +63,6 @@ export const selectMoviesState = state => state.movies;
 export const selectMovies = state => selectMoviesState(state).movies;
 export const selectLoading = state => selectMoviesState(state).loading;
 export const selectError = state => selectMoviesState(state).error;
-export const selectGenresFromMovies = state => selectMoviesState(state).genres;
 export const selectMovie = state => selectMoviesState(state).movieData.movie;
 export const selectMovieCredits = state => selectMoviesState(state).movieData.credits;
 

--- a/src/features/people/peopleSaga.js
+++ b/src/features/people/peopleSaga.js
@@ -6,9 +6,8 @@ import {
   fetchPerson,
   fetchPersonError,
   fetchPersonSucces,
-  setGenres
 } from "./peopleSlice";
-import { getPopularPeople, getPerson, getPersonCredits, getGenres, searchForPeople } from "../../apiClient";
+import { getPopularPeople, getPerson, getPersonCredits, searchForPeople } from "../../apiClient";
 
 function* fetchPeopleHandler({ payload }) {
   try {
@@ -26,9 +25,7 @@ function* fetchPersonHandler(action) {
   try {
     const person = yield call(getPerson, action.payload);
     const credits = yield call(getPersonCredits, action.payload);
-    const genres = yield call(getGenres);
     yield put(fetchPersonSucces({ person, credits }));
-    yield put(setGenres(genres));
   } catch (error) {
     yield put(fetchPersonError());
     console.error(error);

--- a/src/features/people/peopleSlice.js
+++ b/src/features/people/peopleSlice.js
@@ -6,8 +6,7 @@ const peopleSlice = createSlice({
     people: [],
     loading: false,
     error: false,
-    personData: {person: undefined, credits: undefined},
-    genres: [],
+    personData: { person: undefined, credits: undefined },
   },
   reducers: {
     fetchPeople: (state) => {
@@ -34,27 +33,23 @@ const peopleSlice = createSlice({
     fetchPerson: (state) => {
       state.loading = true;
     },
+
     fetchPersonSucces: (state, { payload: personData }) => {
       state.personData = personData;
       state.loading = false;
       state.error = false;
     },
+
     fetchPersonError: (state) => {
       state.loading = false;
       state.error = true;
     },
 
     resetPerson: (state) => {
-      state.personData = {person: undefined, credits: undefined};
+      state.personData = { person: undefined, credits: undefined };
       state.loading = false;
       state.error = false;
     },
-
-    setGenres: (state, { payload: genres }) => {
-      state.genres = genres;
-      state.loading = false;
-      state.error = false;
-  },
   },
 });
 
@@ -64,16 +59,14 @@ export const selectPeopleLoadingState = state => selectPeopleState(state).loadin
 export const selectPeopleErrorState = state => selectPeopleState(state).error;
 export const selectPerson = state => selectPeopleState(state).personData.person;
 export const selectPersonCredits = state => selectPeopleState(state).personData.credits;
-export const selectGenresFromPeople = state => selectPeopleState(state).genres;
 export const {
   fetchPeople,
-  fetchPeopleSucces, 
-  fetchPeopleError, 
+  fetchPeopleSucces,
+  fetchPeopleError,
   resetPeople,
   fetchPerson,
   fetchPersonSucces,
   fetchPersonError,
   resetPerson,
-  setGenres,
 } = peopleSlice.actions;
 export default peopleSlice.reducer;

--- a/src/features/people/peopleSlice.js
+++ b/src/features/people/peopleSlice.js
@@ -12,39 +12,32 @@ const peopleSlice = createSlice({
     fetchPeople: (state) => {
       state.loading = true;
     },
-
     fetchPeopleSucces: (state, { payload: people }) => {
       state.people = people;
       state.loading = false;
       state.error = false;
     },
-
     fetchPeopleError: state => {
       state.loading = false;
       state.error = true;
     },
-
     resetPeople: state => {
       state.people = [];
       state.loading = false;
       state.error = false;
     },
-
     fetchPerson: (state) => {
       state.loading = true;
     },
-
     fetchPersonSucces: (state, { payload: personData }) => {
       state.personData = personData;
       state.loading = false;
       state.error = false;
     },
-
     fetchPersonError: (state) => {
       state.loading = false;
       state.error = true;
     },
-
     resetPerson: (state) => {
       state.personData = { person: undefined, credits: undefined };
       state.loading = false;

--- a/src/rootSaga.js
+++ b/src/rootSaga.js
@@ -1,10 +1,12 @@
 import { all } from "redux-saga/effects";
 import { moviesSaga } from "./features/movies/moviesSaga";
 import { peopleSaga } from "./features/people/peopleSaga";
+import { genresSaga } from "./features/genres/genresSaga";
 
 export default function* rootSaga() {
     yield all([
         moviesSaga(),
         peopleSaga(),
+        genresSaga(),
     ]);
 };

--- a/src/store.js
+++ b/src/store.js
@@ -2,6 +2,7 @@ import { configureStore } from "@reduxjs/toolkit";
 import createSagaMiddleware from "redux-saga";
 import moviesReducer from "./features/movies/moviesSlice";
 import peopleReducer from "./features/people/peopleSlice";
+import genresReducer from "./features/genres/genresSlice";
 import rootSaga from "./rootSaga";
 
 const sagaMiddleware = createSagaMiddleware();
@@ -10,6 +11,7 @@ const store = configureStore({
     reducer: {
         movies: moviesReducer,
         people: peopleReducer,
+        genres: genresReducer,
     },
     middleware: [sagaMiddleware],
 });


### PR DESCRIPTION
Wrzucam kolejnego PR-a. Tym razem przeniesienie genres to osobnego feature'a (slice + saga) oraz drobne poprawki w wyglądzie, czyli wyśrodkowanie kafelka dla mobilnego widoku horizontal, dodanie mobilnego widoku ErrorPage, usunięcie niepotrzebnego resetu w sadze, czyli de facto poprawienie loadingu filmu.
Ogólnie przed zatwierdzeniem to wstawiam taki pomysł do konsultacji, aby genres załadować przy zamontowaniu nie komponentu (czy też strony) MoviesPage, ale komponentu całościowego App. Spowoduje to, że gatunki pobiorą się tylko jeden raz, a w sadze nie będą nawet potrzebne żadne warunki. W tym momencie jest tak, że mimo, że warunek, który wczoraj zaproponowała @katkowa jest, to i tak na zamontowanie MoviesPage mamy rozpoczęcie akcji fetchGenres.