### PR TITLE
Feature/tile poster display improvment

### DIFF
--- a/src/common/PeopleTile/styled.js
+++ b/src/common/PeopleTile/styled.js
@@ -4,7 +4,7 @@ export const StyledTile = styled.div`
   display: flex;
   flex-direction: column;
   width: 248px;
-  min-height: 339px;
+  height: 100%;
   border-radius: 5px;
   background-color: ${({ theme }) => theme.colors.White};
   padding: 16px;

--- a/src/common/Section/styled.js
+++ b/src/common/Section/styled.js
@@ -22,7 +22,7 @@ export const Container = styled.div`
 
   ${({ grid }) =>
     grid && css`
-     grid-auto-rows: minmax(min-content, max-content);
+
     ${({ type }) => type === "movies" && css`
       grid-template-columns: repeat(auto-fill, minmax(324px, 1fr));
     grid-gap: 24px;

--- a/src/common/Section/styled.js
+++ b/src/common/Section/styled.js
@@ -22,6 +22,7 @@ export const Container = styled.div`
 
   ${({ grid }) =>
     grid && css`
+     grid-auto-rows: minmax(min-content, max-content);
     ${({ type }) => type === "movies" && css`
       grid-template-columns: repeat(auto-fill, minmax(324px, 1fr));
     grid-gap: 24px;

--- a/src/common/Section/styled.js
+++ b/src/common/Section/styled.js
@@ -20,17 +20,15 @@ export const Container = styled.div`
   display: ${({ grid }) => (grid ? "grid" : "block")};
   margin: 0 auto;
 
-  ${({ grid }) =>
-    grid && css`
-
+  ${({ grid }) =>  grid && css`
     ${({ type }) => type === "movies" && css`
-      grid-template-columns: repeat(auto-fill, minmax(324px, 1fr));
-    grid-gap: 24px;
+        grid-template-columns: repeat(auto-fill, minmax(324px, 1fr));
+        grid-gap: 24px;
     `}
 
     ${({ type }) => type === "people" && css`
       grid-template-columns: repeat(auto-fill, minmax(248px, 1fr));
-    grid-gap: 32px;
+      grid-gap: 32px;
 
     @media (max-width: ${({ theme }) => theme.breakpoints.mobileMax}) {
       grid-template-columns: repeat(auto-fill, minmax(136px, 0.4fr));

--- a/src/common/Tile/index.js
+++ b/src/common/Tile/index.js
@@ -40,6 +40,7 @@ const Tile = ({ horizontal, title, year, poster, production, release, descriptio
     <StyledTile horizontal={horizontal}>
       <Poster
         horizontal={horizontal}
+        noPoster={!poster}
         src={
           poster
             ? `https://image.tmdb.org/t/p/w342${poster}`

--- a/src/common/Tile/styled.js
+++ b/src/common/Tile/styled.js
@@ -34,21 +34,24 @@ export const StyledTile = styled.div`
         grid-template-columns: 122px 1fr;
         width: 288px;
         padding: 16px;
-        margin: 0 auto;
         box-shadow: 0px 4px 12px rgba(186, 199, 213, 0.5);
       }
     `};
 `;
 
 export const Poster = styled.img`
-  max-width: 292px;
+  width: 292px;
+  height: 434px;
   border-radius: 5px;
   background: ${({ theme }) => theme.colors.Silver};
   object-position: center center;
+  object-fit: cover;
 
   @media (max-width: ${({ theme }) => theme.breakpoints.mobileMax}) {
-    max-width: 114px;
+    width: 114px;
+    height: 169px;
     margin-right: 8px;
+    object-fit: scale-down;
   }
 
   ${({ horizontal }) =>
@@ -58,16 +61,6 @@ export const Poster = styled.img`
 
       @media (max-width: ${({ theme }) => theme.breakpoints.mobileMax}) {
         grid-area: poster;
-      }
-    `};
-
-  ${({ noPoster }) =>
-    noPoster &&
-    css`
-    height: 434px;
-    object-fit: scale-down;
-      @media (max-width: ${({ theme }) => theme.breakpoints.mobileMax}) {
-        height: 169px;
       }
     `};
 `;

--- a/src/common/Tile/styled.js
+++ b/src/common/Tile/styled.js
@@ -55,24 +55,21 @@ export const Poster = styled.img`
       @media (max-width: ${({ theme }) => theme.breakpoints.mobileMax}) {
         height: 169px;
       }
-    `};
+  `};
 
   @media (max-width: ${({ theme }) => theme.breakpoints.mobileMax}) {
     width: 114px;
     height: 169px;
     margin-right: 8px;
-    object-fit: scale-down;
   }
 
-  ${({ horizontal }) =>
-    horizontal &&
-    css`
-      margin-right: 20px;
+  ${({ horizontal }) => horizontal && css`
+    margin-right: 20px;
 
-      @media (max-width: ${({ theme }) => theme.breakpoints.mobileMax}) {
-        grid-area: poster;
-      }
-    `};
+    @media (max-width: ${({ theme }) => theme.breakpoints.mobileMax}) {
+      grid-area: poster;
+    }
+  `};
 `;
 
 export const MovieDetails = styled.section`

--- a/src/common/Tile/styled.js
+++ b/src/common/Tile/styled.js
@@ -4,7 +4,7 @@ export const StyledTile = styled.div`
   display: flex;
   flex-direction: column;
   width: 324px;
-  min-height: 650px;
+  height: 100%;
   border-radius: 5px;
   background-color: ${({ theme }) => theme.colors.White};
   padding: 16px;

--- a/src/common/Tile/styled.js
+++ b/src/common/Tile/styled.js
@@ -4,7 +4,7 @@ export const StyledTile = styled.div`
   display: flex;
   flex-direction: column;
   width: 324px;
-  height: 100%;
+  align-self: stretch;
   border-radius: 5px;
   background-color: ${({ theme }) => theme.colors.White};
   padding: 16px;
@@ -16,7 +16,7 @@ export const StyledTile = styled.div`
     width: 288px;
     min-height: 201px;
   }
-
+  
   ${({ horizontal }) =>
     horizontal &&
     css`
@@ -46,6 +46,16 @@ export const Poster = styled.img`
   background: ${({ theme }) => theme.colors.Silver};
   object-position: center center;
   object-fit: cover;
+
+  ${({ noPoster }) =>
+    noPoster &&
+    css`
+    height: 434px;
+    object-fit: scale-down;
+      @media (max-width: ${({ theme }) => theme.breakpoints.mobileMax}) {
+        height: 169px;
+      }
+    `};
 
   @media (max-width: ${({ theme }) => theme.breakpoints.mobileMax}) {
     width: 114px;

--- a/src/common/Tile/styled.js
+++ b/src/common/Tile/styled.js
@@ -34,24 +34,21 @@ export const StyledTile = styled.div`
         grid-template-columns: 122px 1fr;
         width: 288px;
         padding: 16px;
+        margin: 0 auto;
         box-shadow: 0px 4px 12px rgba(186, 199, 213, 0.5);
       }
     `};
 `;
 
 export const Poster = styled.img`
-  width: 292px;
-  height: 434px;
+  max-width: 292px;
   border-radius: 5px;
   background: ${({ theme }) => theme.colors.Silver};
   object-position: center center;
-  object-fit: scale-down;
 
   @media (max-width: ${({ theme }) => theme.breakpoints.mobileMax}) {
-    width: 114px;
-    height: 169px;
+    max-width: 114px;
     margin-right: 8px;
-    object-fit: scale-down;
   }
 
   ${({ horizontal }) =>
@@ -61,6 +58,16 @@ export const Poster = styled.img`
 
       @media (max-width: ${({ theme }) => theme.breakpoints.mobileMax}) {
         grid-area: poster;
+      }
+    `};
+
+  ${({ noPoster }) =>
+    noPoster &&
+    css`
+    height: 434px;
+    object-fit: scale-down;
+      @media (max-width: ${({ theme }) => theme.breakpoints.mobileMax}) {
+        height: 169px;
       }
     `};
 `;


### PR DESCRIPTION
Hej,
zaintrygowany postem Krzyśka, że niektóre plakaty są w innych proporcjach postanowiłem to sprawdzić u nas.
I u nas dzięki "scale-down" wyświetlały się dobrze ale z paskami na górze i dole (zobaczcie na stronie 5 i 6)
Po usunięciu scale-down niestety się rozciągały co też nie jest dobre.

Postanowiłem zrobić tak, żeby wyświetlały się w swoich właściwych proporcjach. Po prostu te mniejsze są niższe ale po wyrównaniu kafelków to nie powinno mieć znaczenia.

Żeby prawidłowo wyświetlała się zaślepka musiałem dodać atrybut noPoster kiedy go nie ma żeby nadać jakąś wysokość.

W people nie zauważyłem aby coś się źle wyświetlało więc nie ruszam.