### PR TITLE
Feature/visual fixes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,8 +6,17 @@ import Header from "./common/Header";
 import { toMovies, toMovie, toPeople, toPerson } from "./routes";
 import MoviePage from "./features/movies/MoviePage";
 import ProfilePage from "./features/people/ProfilePage/";
+import { useDispatch } from "react-redux";
+import { useEffect } from "react";
+import { fetchGenres } from "./features/genres/genresSlice";
 
 function App() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(fetchGenres());
+  }, [dispatch]);
+
   return (
     <HashRouter>
       <Header />

--- a/src/common/Main/styled.js
+++ b/src/common/Main/styled.js
@@ -1,10 +1,12 @@
 import styled from "styled-components";
 
 export const MainContainer = styled.main`
-  max-width: 1368px;
+  max-width: 1408px;
   margin: 56px auto 40px auto;
+  padding: 0 20px;
 
   @media (max-width: ${({ theme }) => theme.breakpoints.mobileMax}) {
     margin: 24px auto 32px auto;
+    padding: 0 10px;
   } ;
 `;

--- a/src/common/Main/styled.js
+++ b/src/common/Main/styled.js
@@ -3,10 +3,8 @@ import styled from "styled-components";
 export const MainContainer = styled.main`
   max-width: 1368px;
   margin: 56px auto 40px auto;
-  padding: 0 20px;
 
   @media (max-width: ${({ theme }) => theme.breakpoints.mobileMax}) {
     margin: 24px auto 32px auto;
-    padding: 0 10px;
   } ;
 `;

--- a/src/common/Main/styled.js
+++ b/src/common/Main/styled.js
@@ -3,8 +3,10 @@ import styled from "styled-components";
 export const MainContainer = styled.main`
   max-width: 1368px;
   margin: 56px auto 40px auto;
+  padding: 0 20px;
 
   @media (max-width: ${({ theme }) => theme.breakpoints.mobileMax}) {
     margin: 24px auto 32px auto;
+    padding: 0 10px;
   } ;
 `;

--- a/src/common/PeopleTile/styled.js
+++ b/src/common/PeopleTile/styled.js
@@ -187,6 +187,7 @@ export const PersonDescription = styled.p`
   font-size: 20px;
   line-height: 1.6;
   margin-left: -20px;
+  text-align: justify;
 
   @media (max-width: ${({ theme }) => theme.breakpoints.mobileMax}) {
     grid-area: personDescription;

--- a/src/common/PeopleTile/styled.js
+++ b/src/common/PeopleTile/styled.js
@@ -32,7 +32,7 @@ export const StyledTile = styled.div`
           "poster personDetails"
           "personDescription personDescription";
         grid-template-columns: 124px 1fr;
-        width: 290px;
+        width: auto;
         padding: 16px;
         box-shadow: 0px 4px 12px rgba(186, 199, 213, 0.5);
         margin: 0 auto;

--- a/src/common/Tile/GenreSection/index.js
+++ b/src/common/Tile/GenreSection/index.js
@@ -1,17 +1,11 @@
 import React from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import GenreTile from "../GenreTile";
 import { StyledSection } from "./styled";
-import { fetchGenres, selectGenres } from "../../../features/genres/genresSlice";
-import { useEffect } from "react";
+import { selectGenres } from "../../../features/genres/genresSlice";
 
 const GenreSection = ({ horizontal, genres }) => {
-  const dispatch = useDispatch();
   const genresList = useSelector(selectGenres);
-
-  useEffect(() => {
-    !genresList.genres && dispatch(fetchGenres());
-  }, [dispatch, genresList]);
 
   return (
     <StyledSection horizontal={horizontal}>

--- a/src/common/Tile/GenreSection/index.js
+++ b/src/common/Tile/GenreSection/index.js
@@ -1,11 +1,17 @@
 import React from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import GenreTile from "../GenreTile";
 import { StyledSection } from "./styled";
-import { selectGenres } from "../../../features/genres/genresSlice";
+import { fetchGenres, selectGenres } from "../../../features/genres/genresSlice";
+import { useEffect } from "react";
 
 const GenreSection = ({ horizontal, genres }) => {
+  const dispatch = useDispatch();
   const genresList = useSelector(selectGenres);
+
+  useEffect(() => {
+    !genresList.genres && dispatch(fetchGenres());
+  }, [dispatch, genresList]);
 
   return (
     <StyledSection horizontal={horizontal}>

--- a/src/common/Tile/styled.js
+++ b/src/common/Tile/styled.js
@@ -47,6 +47,7 @@ export const Poster = styled.img`
   background: ${({ theme }) => theme.colors.Silver};
   object-position: center center;
   object-fit: cover;
+  flex-shrink: 0;
 
   ${({ noPoster }) =>
     noPoster &&

--- a/src/common/Tile/styled.js
+++ b/src/common/Tile/styled.js
@@ -32,7 +32,7 @@ export const StyledTile = styled.div`
           "poster movieDetails"
           "movieDescription movieDescription";
         grid-template-columns: 122px 1fr;
-        width: 288px;
+        width: auto;
         padding: 16px;
         margin: 0 auto;
         box-shadow: 0px 4px 12px rgba(186, 199, 213, 0.5);

--- a/src/common/Tile/styled.js
+++ b/src/common/Tile/styled.js
@@ -192,6 +192,7 @@ export const MovieDescription = styled.p`
   margin-top: 12px;
   font-size: 20px;
   line-height: 1.6;
+  text-align: justify;
 
   @media (max-width: ${({ theme }) => theme.breakpoints.mobileMax}) {
     grid-area: movieDescription;

--- a/src/features/movies/MoviesPage/index.js
+++ b/src/features/movies/MoviesPage/index.js
@@ -13,7 +13,6 @@ import { useQueryParameter } from "../../../useQueryParameters";
 import { search as searchParameterName } from "../../../queryParamNames";
 import { toMovie } from "../../../routes";
 import NoResultsPage from "../../../common/NoResultsPage";
-import { fetchGenres } from "../../genres/genresSlice";
 import BackToTopButton from "../../../common/BackToTopButton";
 
 const MoviesPage = () => {
@@ -27,7 +26,6 @@ const MoviesPage = () => {
 
   useEffect(() => {
     dispatch(fetchPopularMovies({ page: page || 1, query }));
-    dispatch(fetchGenres());
   }, [dispatch, page, query]);
 
   return (

--- a/src/features/movies/MoviesPage/index.js
+++ b/src/features/movies/MoviesPage/index.js
@@ -26,7 +26,7 @@ const MoviesPage = () => {
 
   useEffect(() => {
     dispatch(fetchPopularMovies({ page: page || 1, query }));
-    return(()=>dispatch(resetMovies()));
+    return (() => dispatch(resetMovies()));
   }, [dispatch, page, query]);
 
   return (


### PR DESCRIPTION
Poprawki wizualne, które wyłapałam. Każdy z nas może mieć inną wizję jak to ma wyglądać i co innego nam się podoba więc to tylko sugestie, można je wdrożyć, a można zostawić tak jak jest.

1. Dodanie padding do main po prawej i lewej stronie, żeby na mniejszych eranach komponenty nie "dotykały" brzegów ekranu.
2. Zmiana, żeby poziome Tile na mobilkach zajmowały całą dostępną szerokość. Mi to osobiście bardzo przeszkadzało że po bokach zostawało dużo przestrzeni a często są tam dość długie opisy i w ten sposób sztucznie przedłużaliśmy stronę.
3. Wyrównanie opisów w Tile'ach do obu brzegów. Dla mnie bardziej elegancko.
4. Poprawa szerokości plakatu dla filmów bez zdjęcia na stronie profilu. Przy długim tytule zaślepka się zwężała.
5. Tu akurat nie wizualnie ale przeniosłam pobieranie gatunków z filmu do sekcji gatunków bo jak długo działałam sobie tylko na people to przeglądarka gubiła tamte dane i nie wyświetlały się gatunki.