### PR TITLE
fix BackToTopButton visibility condition

### DIFF
--- a/src/features/movies/MoviesPage/index.js
+++ b/src/features/movies/MoviesPage/index.js
@@ -65,7 +65,7 @@ const MoviesPage = () => {
                     </FeatureLink>
                   )
               } />
-            <BackToTopButton />
+            {!loading && <BackToTopButton />}
           </Main>
           {!loading && <Pagination type="movies" />}
         </>

--- a/src/features/people/PeoplePage/index.js
+++ b/src/features/people/PeoplePage/index.js
@@ -63,7 +63,7 @@ const PeoplePage = () => {
                   ))
               }
             />
-            <BackToTopButton />
+            {!loading && <BackToTopButton />}
           </Main>
         </>
       }


### PR DESCRIPTION
Mała, ale wbrew pozorom istotna korekta. Przed nią, w trakcie wyszukiwania pojawiał się i LoadingSpinner i BackToTopButton, dodałem w PeoplePage i MoviesPage warunki, aby tak się nie działo ;)